### PR TITLE
Add cocco, 4p2z, and cesm2.1 settings

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -206,8 +206,8 @@
 
   <entry id="OCN_BGC_CONFIG">
     <type>char</type>
-    <valid_values>latest,cesm2.0</valid_values>
-    <default_value>latest</default_value>
+    <valid_values>latest,latest+cocco,latest+4p2z,cesm2.0,cesm2.1,cesm2.1+cocco</valid_values>
+    <default_value>latest+4p2z</default_value>
     <values>
 	<value compset="POP2%[^_]*ECOCESM20">cesm2.0</value>
     </values>


### PR DESCRIPTION
Updated `OCN_BGC_CONFIG` to allow additional MARBL configurations out of the box (every configuration defined in the marbl0.43.1 tag that POP is using can be enabled with `xmlchange`). The default was changed to `latest+4p2z`, to match the configuration that is recommended with the emissions-based CESM using this version of POP.

Note: I made these changes on my laptop, and haven't tested them in the context of the full CESM2.1.5-CCIS-Ens yet. I'm happy to create a sandbox on derecho and verify that it works as expected, but was hoping @lawrencepj1 could just check out my branch and quickly create a case to verify (a) `create_newcase` doesn't crash, and (b) `./xmlquery OCN_BGC_CONFIG` shows `latest+4p2z`